### PR TITLE
Make it easier to use partial response with jackson+jaxrs.

### DIFF
--- a/filter-json-jackson-jaxrs/README.md
+++ b/filter-json-jackson-jaxrs/README.md
@@ -1,0 +1,63 @@
+Partial Response - JAX-RS Jackson JSON Filter
+=============================================
+
+This project makes it easy to add partial response filtering to your JAX-RS based REST API.
+
+If your REST api is built using JAX-RS 2.0 and uses Jackson to do the JSON serialisation from Java POJOs then this
+library should be able to help you.
+
+Usage
+-----
+
+To use this library in your Maven project simply include the dependency
+
+```xml
+<dependency>
+  <groupId>com.pressassociation.partial-response</groupId>
+  <artifactId>filter-json-jackson-jaxrs</artifactId>
+  <version>1.0</version>
+</dependency>
+```
+
+Depending on your JAX-RS implementation you may also need to configure your JAX-RS environment so that it is aware of
+the `FilteredObjectMapperResolver`. In general this involves including an instance of this class in your `Application`
+providers list.
+
+The `FilteredObjectMapperResolver` is annotated with JSR-330 `@Inject` annotations as a mechanism to resolve it's
+dependencies, if you are using a container or environment that doesn't support JSR-330 then you will need to configure
+the `FilteredObjectMapperResolver` manually. You may also need to do this if you plan on changing the default `fields`
+request parameter that is used to populate the partial response pattern from the incoming request.
+
+### Advanced Usage
+
+If you are already customising the `ObjectMapper` for your JAX-RS Jackson application then you should look at the
+`JacksonRequestParamFilter`. This class encapsulates the configuration of `ObjectMapper` for re-use without the baggage
+brought by a full JAX-RS filter. To use you should obtain an instance of `JacksonRequestParamFilter` via your favourite
+DI method and call its `configurePartialResponse` method on the `ObjectMapper` instance.
+
+```java
+@Provider
+@Singleton
+public class IndentedObjectMapperResolver implements ContextResolver<ObjectMapper> {
+
+  private final JacksonRequestParamFilter paramFilter;
+
+  @Inject
+  public IndentedObjectMapperResolver(JacksonRequestParamFilter paramFilter) {
+    this.paramFilter = checkNotNull(paramFilter);
+  }
+
+  @Override
+  public ObjectMapper getContext(Class<?> type) {
+    ObjectMapper mapper = new ObjectMapper();
+
+    // do my own customisation
+    mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+    // configure the partial response filter
+    paramFilter.configurePartialResponse(mapper);
+
+    return mapper;
+  }
+}
+```

--- a/filter-json-jackson-jaxrs/pom.xml
+++ b/filter-json-jackson-jaxrs/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>partial-response</artifactId>
+    <groupId>com.pressassociation.partial-response</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <!-- http://maven.apache.org/developers/conventions/code.html -->
+
+  <artifactId>filter-json-jackson-jaxrs</artifactId>
+
+  <name>Partial Response: JAX-RS Jackson JSON Filter</name>
+  <description>filter-json-jackson-jaxrs module</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>filter-json-jackson</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>2.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+    </dependency>
+    <!-- used to help test against the jax-rs api -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <version>3.0.10.Final</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/filter-json-jackson-jaxrs/src/main/java/com/pressassociation/pr/filter/json/jackson/FilteredObjectMapperResolver.java
+++ b/filter-json-jackson-jaxrs/src/main/java/com/pressassociation/pr/filter/json/jackson/FilteredObjectMapperResolver.java
@@ -1,0 +1,37 @@
+package com.pressassociation.pr.filter.json.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * <p>Standard ContextResolver for resolving an ObjectMapper than filters output based on a partial response field.
+ *
+ * <p>This class can be used as is to provide default partial response filtering of all json responses. If, however,
+ * you need more control over the creation of the ObjectMapper consider using {@link JacksonRequestParamFilter}
+ * directly instead of overriding this class to add your functionality.
+ *
+ * @author Matt Nathan
+ */
+@Provider
+@Singleton
+public class FilteredObjectMapperResolver implements ContextResolver<ObjectMapper> {
+
+  private final JacksonRequestParamFilter paramFilter;
+
+  @Inject
+  public FilteredObjectMapperResolver(JacksonRequestParamFilter paramFilter) {
+    this.paramFilter = checkNotNull(paramFilter);
+  }
+
+  @Override
+  public ObjectMapper getContext(Class<?> type) {
+    checkNotNull(type);
+    return paramFilter.configurePartialResponse(new ObjectMapper());
+  }
+}

--- a/filter-json-jackson-jaxrs/src/main/java/com/pressassociation/pr/filter/json/jackson/JacksonRequestParamFilter.java
+++ b/filter-json-jackson-jaxrs/src/main/java/com/pressassociation/pr/filter/json/jackson/JacksonRequestParamFilter.java
@@ -1,0 +1,57 @@
+package com.pressassociation.pr.filter.json.jackson;
+
+import com.google.common.base.Strings;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Encapsulates the logic for filtering a request against a partial response.
+ *
+ * @author Matt Nathan
+ */
+public class JacksonRequestParamFilter {
+  /**
+   * Default field name for the partial response field.
+   */
+  public static final String DEFAULT_FIELD_NAME = "fields";
+
+  private final Provider<UriInfo> uriInfo;
+  private final String fieldName;
+
+  /**
+   * Create a new JacksonRequestParamFilter using the {@link #DEFAULT_FIELD_NAME default} field name of {@code fields}.
+   */
+  @Inject
+  public JacksonRequestParamFilter(Provider<UriInfo> uriInfo) {
+    this(uriInfo, DEFAULT_FIELD_NAME);
+  }
+
+  /**
+   * Create a new JacksonRequestParamFilter that uses the given {@code fieldName}.
+   */
+  public JacksonRequestParamFilter(Provider<UriInfo> uriInfo, String fieldName) {
+    this.uriInfo = checkNotNull(uriInfo);
+    this.fieldName = checkNotNull(fieldName);
+  }
+
+  /**
+   * Configure the given ObjectMapper to filter output based on a request parameter interpreted as a partial response
+   * pattern.
+   */
+  public ObjectMapper configurePartialResponse(ObjectMapper mapper) {
+    checkNotNull(mapper);
+    MultivaluedMap<String, String> queryParameters = uriInfo.get().getQueryParameters();
+    String fieldValue = queryParameters.getFirst(fieldName);
+    if (!Strings.isNullOrEmpty(fieldValue)) {
+      JacksonFilters.filterAllOutput(mapper, fieldValue);
+    }
+    return mapper;
+  }
+}

--- a/filter-json-jackson-jaxrs/src/test/java/com/pressassociation/pr/filter/json/jackson/FilteredObjectMapperResolverTest.java
+++ b/filter-json-jackson-jaxrs/src/test/java/com/pressassociation/pr/filter/json/jackson/FilteredObjectMapperResolverTest.java
@@ -1,0 +1,28 @@
+package com.pressassociation.pr.filter.json.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link FilteredObjectMapperResolver}.
+ */
+public class FilteredObjectMapperResolverTest {
+
+  @Test
+  public void testGetContext() {
+    JacksonRequestParamFilter filter = mock(JacksonRequestParamFilter.class);
+    ObjectMapper mapperResponse = new ObjectMapper();
+    ArgumentCaptor<ObjectMapper> mapper = ArgumentCaptor.forClass(ObjectMapper.class);
+    when(filter.configurePartialResponse(mapper.capture())).thenReturn(mapperResponse);
+    ObjectMapper context = new FilteredObjectMapperResolver(filter).getContext(ObjectMapper.class);
+    assertSame(mapperResponse, context);
+    verify(filter).configurePartialResponse(mapper.getValue());
+  }
+}

--- a/filter-json-jackson-jaxrs/src/test/java/com/pressassociation/pr/filter/json/jackson/JacksonRequestParamFilterTest.java
+++ b/filter-json-jackson-jaxrs/src/test/java/com/pressassociation/pr/filter/json/jackson/JacksonRequestParamFilterTest.java
@@ -1,0 +1,136 @@
+package com.pressassociation.pr.filter.json.jackson;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.ser.PropertyFilter;
+import com.pressassociation.fire.partialresponse.fields.match.Matcher;
+
+import org.jboss.resteasy.spi.ResteasyUriInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URI;
+
+import javax.annotation.Nullable;
+import javax.inject.Provider;
+import javax.ws.rs.core.UriInfo;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link JacksonRequestParamFilter}.
+ */
+@RunWith(JUnitParamsRunner.class)
+public class JacksonRequestParamFilterTest {
+
+  /**
+   * Parameter encapsulation for variation testing.
+   */
+  public static class Params {
+
+    public static Params applies(String uri, CharSequence pattern) {
+      return create(uri, pattern);
+    }
+
+    public static Params absent(String uri) {
+      return create(uri, null);
+    }
+
+    private static Params create(String uri, @Nullable CharSequence pattern) {
+      Optional<Matcher> matcher = pattern == null ? Optional.<Matcher>absent() : Optional.of(Matcher.of(pattern));
+      return new Params("http://test/?" + uri, matcher);
+    }
+
+    final String uri;
+    final Optional<Matcher> matcher;
+
+    public Params(String uri, Optional<Matcher> matcher) {
+      this.uri = checkNotNull(uri);
+      this.matcher = checkNotNull(matcher);
+    }
+
+    public UriInfo getUriInfo() {
+      return new ResteasyUriInfo(URI.create(uri));
+    }
+
+    public Provider<UriInfo> scopedUriInfo() {
+      return new Provider<UriInfo>() {
+        @Override
+        public UriInfo get() {
+          return getUriInfo();
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if (matcher.isPresent()) {
+        return "URI " + uri + " should apply partial response of " + matcher.get();
+      } else {
+        return "URI " + uri + " should have no partial response applied";
+      }
+    }
+  }
+
+  @Test
+  @Parameters(method = "params")
+  public void testConfigurePartialResponse(Params params) {
+    JacksonRequestParamFilter subject = new JacksonRequestParamFilter(params.scopedUriInfo());
+    ObjectMapper mapper = subject.configurePartialResponse(new ObjectMapper());
+
+    if (params.matcher.isPresent()) {
+      assertConfiguredWithMatcher(mapper, params.matcher.get());
+    } else {
+      assertConfiguredWithoutMatcher(mapper);
+    }
+  }
+
+  public Iterable<Params> params() {
+    return ImmutableList.of(
+        Params.absent(""),
+        Params.absent("fields="),
+        Params.absent("fields"),
+        Params.absent("random=foo/bar"),
+        Params.applies("fields=foo/bar", "foo/bar"),
+        Params.applies("fields=*", "*"),
+        Params.applies("fields=a,b", "a,b")
+    );
+  }
+
+  private void assertConfiguredWithMatcher(ObjectMapper mapper, Matcher matcher) {
+    AnnotationIntrospector introspector = mapper.getSerializationConfig().getAnnotationIntrospector();
+    Object filterId = introspector.findFilterId((Annotated) AnnotatedClass.construct(
+        TestObject.class, introspector, mapper.getDeserializationConfig()));
+    assertNotNull(filterId);
+
+    PropertyFilter propertyFilter =
+        mapper.getSerializationConfig().getFilterProvider().findPropertyFilter(filterId, new TestObject());
+    assertNotNull(propertyFilter);
+    assertTrue(propertyFilter instanceof JacksonMatcherFilter);
+    assertEquals(matcher, ((JacksonMatcherFilter) propertyFilter).getMatcher());
+  }
+
+  private void assertConfiguredWithoutMatcher(ObjectMapper mapper) {
+    AnnotationIntrospector introspector = mapper.getSerializationConfig().getAnnotationIntrospector();
+    Object filterId = introspector.findFilterId((Annotated) AnnotatedClass.construct(
+        TestObject.class, introspector, mapper.getDeserializationConfig()));
+    assertNull(filterId);
+  }
+
+  /**
+   * Test object for ObjectMapper tests.
+   */
+  private static class TestObject {}
+}

--- a/filter-json-jackson-jaxrs/src/test/java/com/pressassociation/pr/filter/json/jackson/JacksonRequestParamFilterTest.java
+++ b/filter-json-jackson-jaxrs/src/test/java/com/pressassociation/pr/filter/json/jackson/JacksonRequestParamFilterTest.java
@@ -84,6 +84,11 @@ public class JacksonRequestParamFilterTest {
     }
   }
 
+  /**
+   * Test object for ObjectMapper tests.
+   */
+  private static class TestObject {}
+
   @Test
   @Parameters(method = "params")
   public void testConfigurePartialResponse(Params params) {
@@ -97,7 +102,8 @@ public class JacksonRequestParamFilterTest {
     }
   }
 
-  public Iterable<Params> params() {
+  @SuppressWarnings("UnusedDeclaration")
+  private Iterable<Params> params() {
     return ImmutableList.of(
         Params.absent(""),
         Params.absent("fields="),
@@ -128,9 +134,4 @@ public class JacksonRequestParamFilterTest {
         TestObject.class, introspector, mapper.getDeserializationConfig()));
     assertNull(filterId);
   }
-
-  /**
-   * Test object for ObjectMapper tests.
-   */
-  private static class TestObject {}
 }

--- a/filter-json-jackson-jaxrs/src/test/java/com/pressassociation/pr/filter/json/jackson/PackageSanityTest.java
+++ b/filter-json-jackson-jaxrs/src/test/java/com/pressassociation/pr/filter/json/jackson/PackageSanityTest.java
@@ -18,6 +18,7 @@ public class PackageSanityTest extends AbstractPackageSanityTests {
   @Override
   public void setUp() throws Exception {
     super.setUp();
+    setDefault(JacksonRequestParamFilter.class, mock(JacksonRequestParamFilter.class));
     setDefault(Matcher.class, Matcher.all());
     setDefault(JsonGenerator.class, mock(JsonGenerator.class));
     setDefault(SerializerProvider.class, mock(SerializerProvider.class));

--- a/filter-json-jackson/pom.xml
+++ b/filter-json-jackson/pom.xml
@@ -42,6 +42,10 @@
       <artifactId>mockito-all</artifactId>
     </dependency>
     <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
     </dependency>

--- a/filter-json-jackson/src/main/java/com/pressassociation/pr/filter/json/jackson/JacksonFilters.java
+++ b/filter-json-jackson/src/main/java/com/pressassociation/pr/filter/json/jackson/JacksonFilters.java
@@ -1,0 +1,40 @@
+package com.pressassociation.pr.filter.json.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.pressassociation.fire.partialresponse.fields.match.Matcher;
+
+/**
+ * Set of utilities for filtering Jackson output based on partial response.
+ *
+ * @author Matt Nathan
+ */
+public class JacksonFilters {
+
+  private static final String FILTER_ID = "PartialResponse";
+
+  /**
+   * Filter all serialised output via the given ObjectMapper with the given pattern.
+   */
+  public static ObjectMapper filterAllOutput(ObjectMapper mapper, CharSequence pattern) {
+    return filterAllOutput(mapper, Matcher.of(pattern));
+  }
+
+  /**
+   * Filter all serialised output via the given ObjectMapper with the given matcher.
+   */
+  public static ObjectMapper filterAllOutput(ObjectMapper mapper, Matcher matcher) {
+    mapper.setFilters(new SimpleFilterProvider().addFilter(FILTER_ID, new JacksonMatcherFilter(matcher)));
+    mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector() {
+      @Override
+      public Object findFilterId(Annotated a) {
+        return FILTER_ID;
+      }
+    });
+    return mapper;
+  }
+
+  private JacksonFilters() {}
+}

--- a/filter-json-jackson/src/main/java/com/pressassociation/pr/filter/json/jackson/JacksonMatcherFilter.java
+++ b/filter-json-jackson/src/main/java/com/pressassociation/pr/filter/json/jackson/JacksonMatcherFilter.java
@@ -52,6 +52,13 @@ public class JacksonMatcherFilter extends SimpleBeanPropertyFilter {
     this.matcher = checkNotNull(matcher);
   }
 
+  /**
+   * Get the matcher this filter is based on.
+   */
+  public Matcher getMatcher() {
+    return matcher;
+  }
+
   @Override
   public void serializeAsField(Object pojo, JsonGenerator jGen, SerializerProvider provider, PropertyWriter writer)
       throws Exception {

--- a/filter-json-jackson/src/test/java/com/pressassociation/pr/filter/json/jackson/JacksonFiltersTest.java
+++ b/filter-json-jackson/src/test/java/com/pressassociation/pr/filter/json/jackson/JacksonFiltersTest.java
@@ -44,6 +44,11 @@ public class JacksonFiltersTest {
     public abstract ObjectMapper filterAllOutput(ObjectMapper mapper, CharSequence input);
   }
 
+  /**
+   * Test object for ObjectMapper tests.
+   */
+  private static class TestObject {}
+
   @Test
   @Parameters(method = "methods")
   public void testFilterAllOutput(OverloadedFilterAllOutput method) {
@@ -60,12 +65,8 @@ public class JacksonFiltersTest {
     assertEquals(Matcher.of("foo/bar"), ((JacksonMatcherFilter) propertyFilter).getMatcher());
   }
 
-  public OverloadedFilterAllOutput[] methods() {
+  @SuppressWarnings("UnusedDeclaration")
+  private OverloadedFilterAllOutput[] methods() {
     return OverloadedFilterAllOutput.values();
   }
-
-  /**
-   * Test object for ObjectMapper tests.
-   */
-  private static class TestObject {}
 }

--- a/filter-json-jackson/src/test/java/com/pressassociation/pr/filter/json/jackson/JacksonFiltersTest.java
+++ b/filter-json-jackson/src/test/java/com/pressassociation/pr/filter/json/jackson/JacksonFiltersTest.java
@@ -1,0 +1,71 @@
+package com.pressassociation.pr.filter.json.jackson;
+
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.ser.PropertyFilter;
+import com.pressassociation.fire.partialresponse.fields.match.Matcher;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link JacksonFilters}.
+ */
+@RunWith(JUnitParamsRunner.class)
+public class JacksonFiltersTest {
+
+  /**
+   * Different overloaded methods under test.
+   */
+  public static enum OverloadedFilterAllOutput {
+    CHAR_SEQUENCE {
+      @Override
+      public ObjectMapper filterAllOutput(ObjectMapper mapper, CharSequence input) {
+        return JacksonFilters.filterAllOutput(mapper, input);
+      }
+    },
+
+    MATCHER {
+      @Override
+      public ObjectMapper filterAllOutput(ObjectMapper mapper, CharSequence input) {
+        return JacksonFilters.filterAllOutput(mapper, Matcher.of(input));
+      }
+    };
+
+    public abstract ObjectMapper filterAllOutput(ObjectMapper mapper, CharSequence input);
+  }
+
+  @Test
+  @Parameters(method = "methods")
+  public void testFilterAllOutput(OverloadedFilterAllOutput method) {
+    ObjectMapper mapper = method.filterAllOutput(new ObjectMapper(), "foo/bar");
+    AnnotationIntrospector introspector = mapper.getSerializationConfig().getAnnotationIntrospector();
+    Object filterId = introspector.findFilterId((Annotated) AnnotatedClass.construct(
+        TestObject.class, introspector, mapper.getDeserializationConfig()));
+    assertNotNull(filterId);
+
+    PropertyFilter propertyFilter =
+        mapper.getSerializationConfig().getFilterProvider().findPropertyFilter(filterId, new TestObject());
+    assertNotNull(propertyFilter);
+    assertTrue(propertyFilter instanceof JacksonMatcherFilter);
+    assertEquals(Matcher.of("foo/bar"), ((JacksonMatcherFilter) propertyFilter).getMatcher());
+  }
+
+  public OverloadedFilterAllOutput[] methods() {
+    return OverloadedFilterAllOutput.values();
+  }
+
+  /**
+   * Test object for ObjectMapper tests.
+   */
+  private static class TestObject {}
+}

--- a/filter-json-jackson/src/test/java/com/pressassociation/pr/filter/json/jackson/JacksonMatcherFilterTest.java
+++ b/filter-json-jackson/src/test/java/com/pressassociation/pr/filter/json/jackson/JacksonMatcherFilterTest.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 /**
  * Tests for {@link JacksonMatcherFilter}.
@@ -247,6 +248,12 @@ public class JacksonMatcherFilterTest {
         "    \"name\" : \"Black Beauty\"\n" +
         "  } ]\n" +
         '}');
+  }
+
+  @Test
+  public void testGetMatcher() {
+    Matcher matcher = Matcher.of("foo/bar");
+    assertSame(matcher, new JacksonMatcherFilter(matcher).getMatcher());
   }
 
   private void assertMatchesJson(CharSequence fields, String json) throws JsonProcessingException {

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <module>check-style</module>
     <module>field-parser</module>
     <module>filter-json-jackson</module>
+    <module>filter-json-jackson-jaxrs</module>
   </modules>
 
   <properties>
@@ -101,6 +102,12 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava-testlib</artifactId>
         <version>${guava.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>pl.pragmatists</groupId>
+        <artifactId>JUnitParams</artifactId>
+        <version>1.0.2</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This adds a new utility to the jackson module: JacksonFilters - which can be used to configure an ObjectMapper to filter based on a partial response pattern.

I've also added a new module that adds jax-rs specific code to interact with the jackson-jaxrs module, providing a ContextResolver for ObjectMapper that looks for a request parameter and automatically applies the partial response filter for you.

Fixes #5
